### PR TITLE
Install both .NET 6 and 8 in local folder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,11 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.x
+          dotnet-version: |
+            6.x
+            8.x
+        env:
+          DOTNET_INSTALL_DIR: '~/dotnet'
 
       - name: Build
         run: dotnet build --configuration Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,9 +36,12 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.x
           source-url: https://nuget.pkg.github.com/centeva/index.json
+          dotnet-version: |
+            6.x
+            8.x
         env:
+          DOTNET_INSTALL_DIR: '~/dotnet'
           NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
       - name: Build


### PR DESCRIPTION
This prevents errors on the build runners because the runner cannot access the system folder to make changes.

We target both versions for this package, so make sure they're available or the build will fail.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Tests
- [x] 🤖 Build/CI
- [ ] 📦 Chore (Version bump, release, etc.)
- [ ] ⏩ Revert

## Quality Checklist

- [x] I have added or updated automated tests as needed.
- [x] I have reviewed the code changes myself.
- [x] I have used commit messages that adequately explain my changes.
- [x] I have removed any extra logging, debugging code, and commented out code.
- [x] I have updated any related documentation (if necessary).

## Additional Notes

<!--
Add any additional notes or context that may be helpful for reviewers.
-->
