### PR TITLE
Add GetAsync() method to retrieve metadata for a stored object

### DIFF
--- a/src/Centeva.ObjectStorage/IObjectStorage.cs
+++ b/src/Centeva.ObjectStorage/IObjectStorage.cs
@@ -29,6 +29,14 @@ public interface IObjectStorage
     Task<Stream?> OpenReadAsync(StoragePath storagePath, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Get information about a stored object at the given path
+    /// </summary>
+    /// <param name="storagePath"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    Task<StorageEntry?> GetAsync(StoragePath storagePath, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Write to a stored object with the given name via a stream
     /// </summary>
     /// <param name="storagePath"></param>

--- a/src/Centeva.ObjectStorage/StorageEntry.cs
+++ b/src/Centeva.ObjectStorage/StorageEntry.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Centeva.ObjectStorage;
+public class StorageEntry
+{
+    /// <summary>
+    /// Path of this entry within the context of the storage provider
+    /// </summary>
+    public StoragePath Path { get; internal set; }
+
+    /// <summary>
+    /// Name of the entry, which is the last part of the path
+    /// </summary>
+    public string Name => Path.Name;
+
+    /// <summary>
+    /// Time of creation of this entry, if known
+    /// </summary>
+    public DateTimeOffset? CreationTime { get; set; }
+
+    /// <summary>
+    /// Time of last modification of this entry, if known
+    /// </summary>
+    public DateTimeOffset? LastModificationTime { get; set; }
+
+    /// <summary>
+    /// Size of this entry in bytes, if known
+    /// </summary>
+    public long? SizeInBytes { get; set; }
+
+    public StorageEntry(string path)
+    {
+        SetPath(path); 
+    }
+
+    public void SetPath(string path)
+    {
+        Path = path;
+    }
+}

--- a/test/Centeva.ObjectStorage.IntegrationTests/Providers/AwsS3ObjectStorageTests.cs
+++ b/test/Centeva.ObjectStorage.IntegrationTests/Providers/AwsS3ObjectStorageTests.cs
@@ -18,7 +18,7 @@ public class AwsS3ObjectStorageFixture : ObjectStorageFixture
     }
 }
 
-public class AwsS3ObjectStorageTests : ObjectStorageTest, IClassFixture<AwsS3ObjectStorageFixture>
+public class AwsS3ObjectStorageTests : CommonObjectStorageTests, IClassFixture<AwsS3ObjectStorageFixture>
 {
     public AwsS3ObjectStorageTests(AwsS3ObjectStorageFixture fixture) : base(fixture)
     {

--- a/test/Centeva.ObjectStorage.IntegrationTests/Providers/AzureBlobObjectStorageTests.cs
+++ b/test/Centeva.ObjectStorage.IntegrationTests/Providers/AzureBlobObjectStorageTests.cs
@@ -18,7 +18,7 @@ public class AzureBlobObjectStorageFixture : ObjectStorageFixture
     }
 }
 
-public class AzureBlobObjectStorageTests : ObjectStorageTest, IClassFixture<AzureBlobObjectStorageFixture>
+public class AzureBlobObjectStorageTests : CommonObjectStorageTests, IClassFixture<AzureBlobObjectStorageFixture>
 {
     public AzureBlobObjectStorageTests(AzureBlobObjectStorageFixture fixture) : base(fixture)
     {

--- a/test/Centeva.ObjectStorage.IntegrationTests/Providers/DiskObjectStorageTests.cs
+++ b/test/Centeva.ObjectStorage.IntegrationTests/Providers/DiskObjectStorageTests.cs
@@ -1,4 +1,6 @@
-﻿using Centeva.ObjectStorage.Builtin;
+﻿using System.Text;
+
+using Centeva.ObjectStorage.Builtin;
 
 namespace Centeva.ObjectStorage.IntegrationTests.Providers;
 
@@ -21,9 +23,27 @@ public class DiskObjectStorageFixture : ObjectStorageFixture
     }
 }
 
-public class DiskObjectStorageTests : ObjectStorageTest, IClassFixture<DiskObjectStorageFixture>
+public class DiskObjectStorageTests : CommonObjectStorageTests, IClassFixture<DiskObjectStorageFixture>
 {
     public DiskObjectStorageTests(DiskObjectStorageFixture fixture) : base(fixture)
     {
     }
+
+    [Fact]
+    public async Task GetAsync_WithFolderPath_RetrievesStorageEntry()
+    {
+        var path = RandomStoragePath("stat");
+        await _sut.WriteAsync(path, new MemoryStream(Encoding.UTF8.GetBytes(_testFileContent)));
+
+        var folderPath = new StoragePath(path.Folder);
+        var entry = await _sut.GetAsync(folderPath);
+
+        entry.Should().NotBeNull();
+        entry!.Path.Full.Should().Be(folderPath);
+        entry.Path.IsFolder.Should().BeTrue();
+        entry.CreationTime.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(1));
+        entry.LastModificationTime.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(1));
+        entry.SizeInBytes.Should().BeNull();
+    }
+
 }

--- a/test/Centeva.ObjectStorage.IntegrationTests/Providers/GoogleObjectStorageTests.cs
+++ b/test/Centeva.ObjectStorage.IntegrationTests/Providers/GoogleObjectStorageTests.cs
@@ -18,7 +18,7 @@ public class GoogleObjectStorageFixture : ObjectStorageFixture
     }
 }
 
-public class GoogleObjectStorageTests : ObjectStorageTest, IClassFixture<GoogleObjectStorageFixture>
+public class GoogleObjectStorageTests : CommonObjectStorageTests, IClassFixture<GoogleObjectStorageFixture>
 {
     public GoogleObjectStorageTests(GoogleObjectStorageFixture fixture) : base(fixture)
     {

--- a/test/Centeva.ObjectStorage.UnitTests/Fixtures/TestProvider.cs
+++ b/test/Centeva.ObjectStorage.UnitTests/Fixtures/TestProvider.cs
@@ -37,4 +37,9 @@ internal class TestProvider : ISignedUrlObjectStorage
     {
         throw new NotImplementedException();
     }
+
+    public Task<StorageEntry?> GetAsync(StoragePath storagePath, CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException();
+    }
 }

--- a/test/Centeva.ObjectStorage.UnitTests/StorageEntryTests.cs
+++ b/test/Centeva.ObjectStorage.UnitTests/StorageEntryTests.cs
@@ -1,0 +1,70 @@
+﻿namespace Centeva.ObjectStorage.UnitTests;
+
+public class StorageEntryTests
+{
+    [Fact]
+    public void Constructor_SetsPath()
+    {
+        var path = "/path/to/file.txt";
+        var entry = new StorageEntry(path);
+
+        Assert.Equal(path, entry.Path.Full);
+    }
+
+    [Fact]
+    public void SetPath_SetsPath()
+    {
+        var path = "/path/to/file.txt";
+        var entry = new StorageEntry(path);
+
+        var newPath = "/new/path/to/file.txt";
+        entry.SetPath(newPath);
+
+        Assert.Equal(newPath, entry.Path.Full);
+    }
+
+    [Fact]
+    public void Name_ReturnsName()
+    {
+        var path = "/path/to/file.txt";
+        var entry = new StorageEntry(path);
+
+        Assert.Equal("file.txt", entry.Name);
+    }
+
+    [Fact]
+    public void CreationTime_ReturnsCreationTime()
+    {
+        var path = "/path/to/file.txt";
+        var entry = new StorageEntry(path);
+
+        var time = DateTimeOffset.Now;
+        entry.CreationTime = time;
+
+        Assert.Equal(time, entry.CreationTime);
+    }
+
+    [Fact]
+    public void LastModificationTime_ReturnsLastModificationTime()
+    {
+        var path = "/path/to/file.txt";
+        var entry = new StorageEntry(path);
+
+        var time = DateTimeOffset.Now;
+        entry.LastModificationTime = time;
+
+        Assert.Equal(time, entry.LastModificationTime);
+    }
+
+    [Fact]
+    public void SizeInBytes_ReturnsSizeInBytes()
+    {
+        var path = "/path/to/file.txt";
+        var entry = new StorageEntry(path);
+
+        var size = 1234;
+        entry.SizeInBytes = size;
+
+        Assert.Equal(size, entry.SizeInBytes);
+    }
+}


### PR DESCRIPTION
Only the Disk provider will retrieve folder metadata, as the others don't have the concept of folders.

+semver:minor

## Description

The GetAsync() method will retrieve minimal information about a stored object, including creation time, modification time, and size. 

We can add additional properties later, as most of the cloud providers have more available.  See #5 for the root issue.

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Tests
- [ ] 🤖 Build/CI
- [ ] 📦 Chore (Version bump, release, etc.)
- [ ] ⏩ Revert

## Related Tickets & Documents

#5 

## Quality Checklist

- [x] I have added or updated automated tests as needed.
- [x] I have reviewed the code changes myself.
- [x] I have used commit messages that adequately explain my changes.
- [x] I have removed any extra logging, debugging code, and commented out code.
- [x] I have updated any related documentation (if necessary).

## Additional Notes

<!--
Add any additional notes or context that may be helpful for reviewers.
-->
