### PR TITLE
Build pull request code and not main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches: [main]
-  pull_request_target: # Needed to access secrets
+  pull_request:
     branches: [main]
 jobs:
   build:


### PR DESCRIPTION
Our PR workflows were building from the main branch instead of the new code.  It was originally done this way because the secrets needed for integration tests weren't being made available.  Maybe there's another solution.


