### PR TITLE
Make connection string keys case insensitive

### DIFF
--- a/src/Centeva.ObjectStorage.Azure.Blob/AzureBlobConnectionFactory.cs
+++ b/src/Centeva.ObjectStorage.Azure.Blob/AzureBlobConnectionFactory.cs
@@ -6,10 +6,10 @@ public class AzureBlobConnectionFactory : IConnectionFactory
 {
     private const string ProviderName = "azure.blob";
     private const string LegacyProviderName = "azure";
-    private const string AccountName = "AccountName";
-    private const string AccountKey = "AccountKey";
-    private const string Endpoint = "Endpoint";
-    private const string Container = "Container";
+    private const string AccountName = "accountName";
+    private const string AccountKey = "accountKey";
+    private const string Endpoint = "endpoint";
+    private const string Container = "container";
 
     public IObjectStorage? CreateConnection(ObjectStorageConnectionString connectionString)
     {

--- a/src/Centeva.ObjectStorage/Connections/ObjectStorageConnectionString.cs
+++ b/src/Centeva.ObjectStorage/Connections/ObjectStorageConnectionString.cs
@@ -4,7 +4,7 @@ public class ObjectStorageConnectionString
 {
     public string ConnectionString { get; }
     public string ProviderName { get; set; } = string.Empty;
-    private readonly Dictionary<string, string?> _parameters = new();
+    private readonly Dictionary<string, string?> _parameters = new(StringComparer.OrdinalIgnoreCase);
 
     private const string ProviderNameSeparator = "://";
     private static readonly char ParameterSeparator = ';';

--- a/test/Centeva.ObjectStorage.UnitTests/Connections/ObjectStorageConnectionStringTests.cs
+++ b/test/Centeva.ObjectStorage.UnitTests/Connections/ObjectStorageConnectionStringTests.cs
@@ -51,6 +51,14 @@ public class ObjectStorageConnectionStringTests
     }
 
     [Fact]
+    public void GetRequired_PerformsCaseInsensitiveLookup()
+    {
+        var str = new ObjectStorageConnectionString("test://Bucket=my_bucket");
+
+        str.GetRequired("bucket").Should().Be("my_bucket");
+    }
+
+    [Fact]
     public void Get_WithMissingParameter_ReturnsNull()
     {
         var str = new ObjectStorageConnectionString("test://bucket=mybucket");
@@ -58,6 +66,13 @@ public class ObjectStorageConnectionStringTests
         str.Get("user").Should().BeNull();
     }
 
+    [Fact]
+    public void Get_PerformsCaseInsensitiveLookup()
+    {
+        var str = new ObjectStorageConnectionString("test://Bucket=my_bucket");
+
+        str.Get("bucket").Should().Be("my_bucket");
+    }
 
     [Theory]
     [InlineData("va=lue")]


### PR DESCRIPTION
* When looking up keys, ignore case
* Standardize the key names to lowercase for Azure Blob provider

+semver:patch

## Description

I noticed this issue when using the Azure provider on my project.  The keys defined for the connection string were capitalized, and I was using lowercase in my code, resulting in an error about missing keys.

This change makes the lookup case insensitive, so you can use "endpoint", "Endpoint", or "endPoint" interchangeably.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Tests
- [ ] 🤖 Build/CI
- [ ] 📦 Chore (Version bump, release, etc.)
- [ ] ⏩ Revert

## Quality Checklist

- [x] I have added or updated automated tests as needed.
- [x] I have reviewed the code changes myself.
- [x] I have used commit messages that adequately explain my changes.
- [ ] I have removed any extra logging, debugging code, and commented out code.
- [ ] I have updated any related documentation (if necessary).

