### PR TITLE
Add azure.blob.identity connection factory to enable identity based auth

### DIFF
--- a/src/Centeva.ObjectStorage.Azure.Blob/AzureBlobConnectionFactory.cs
+++ b/src/Centeva.ObjectStorage.Azure.Blob/AzureBlobConnectionFactory.cs
@@ -1,4 +1,7 @@
-﻿using Centeva.ObjectStorage.Connections;
+﻿using Azure.Core;
+using Azure.Identity;
+
+using Centeva.ObjectStorage.Connections;
 
 namespace Centeva.ObjectStorage.Azure.Blob;
 
@@ -23,5 +26,30 @@ public class AzureBlobConnectionFactory : IConnectionFactory
         var endpoint = connectionString.Get(Endpoint);
 
         return new AzureBlobObjectStorage(accountName, accountKey, container, endpoint is null ? null : new Uri(endpoint));
+    }
+}
+
+public class AzureBlobIdentityConnectionFactory: IConnectionFactory {
+    private const string ProviderName = "azure.blob.identity";
+    private const string AccountName = "accountName";
+    private const string Endpoint = "endpoint";
+    private const string Container = "container";
+    private const string ClientId = "clientId";
+
+    public IObjectStorage? CreateConnection(ObjectStorageConnectionString connectionString) {
+        if (connectionString.ProviderName != ProviderName)
+            return null;
+
+        var container = connectionString.GetRequired(Container);
+        var accountName = connectionString.GetRequired(AccountName);
+        var endpoint = connectionString.Get(Endpoint);
+        var clientId = connectionString.Get(ClientId);
+
+        TokenCredential? identity = null;
+        if (clientId is not null) {
+            identity = new ManagedIdentityCredential(clientId);
+        }
+
+        return new AzureBlobObjectStorage(accountName, container, identity, endpoint is null ? null : new Uri(endpoint));
     }
 }

--- a/src/Centeva.ObjectStorage.Azure.Blob/AzureBlobConnectionFactory.cs
+++ b/src/Centeva.ObjectStorage.Azure.Blob/AzureBlobConnectionFactory.cs
@@ -11,6 +11,7 @@ public class AzureBlobConnectionFactory : IConnectionFactory
     private const string LegacyProviderName = "azure";
     private const string AccountName = "accountName";
     private const string AccountKey = "accountKey";
+    private const string ClientId = "clientId";
     private const string Endpoint = "endpoint";
     private const string Container = "container";
 
@@ -22,31 +23,20 @@ public class AzureBlobConnectionFactory : IConnectionFactory
 
         var container = connectionString.GetRequired(Container);
         var accountName = connectionString.GetRequired(AccountName);
-        var accountKey = connectionString.GetRequired(AccountKey).Replace(' ', '+');
-        var endpoint = connectionString.Get(Endpoint);
-
-        return new AzureBlobObjectStorage(accountName, accountKey, container, endpoint is null ? null : new Uri(endpoint));
-    }
-}
-
-public class AzureBlobIdentityConnectionFactory: IConnectionFactory {
-    private const string ProviderName = "azure.blob.identity";
-    private const string AccountName = "accountName";
-    private const string Endpoint = "endpoint";
-    private const string Container = "container";
-    private const string ClientId = "clientId";
-
-    public IObjectStorage? CreateConnection(ObjectStorageConnectionString connectionString) {
-        if (connectionString.ProviderName != ProviderName)
-            return null;
-
-        var container = connectionString.GetRequired(Container);
-        var accountName = connectionString.GetRequired(AccountName);
-        var endpoint = connectionString.Get(Endpoint);
+        var accountKey = (connectionString.Get(AccountKey) ?? "").Replace(' ', '+');
         var clientId = connectionString.Get(ClientId);
+        var endpoint = connectionString.Get(Endpoint);
 
-        TokenCredential? identity = null;
-        if (clientId is not null) {
+        // If we have an account key, we use shared key authentication
+        if (accountKey is not null and not "") {
+            return new AzureBlobObjectStorage(accountName, accountKey, container, endpoint is null ? null : new Uri(endpoint));
+        }
+
+        // If we don't specify which identity to use, we default to DefaultAzureCredential which will try to use the running environment's identity
+        TokenCredential identity = new DefaultAzureCredential();
+
+        // If we have a client ID, we use managed identity authentication
+        if (clientId is not null and not "") {
             identity = new ManagedIdentityCredential(clientId);
         }
 

--- a/src/Centeva.ObjectStorage.Azure.Blob/AzureBlobObjectStorage.cs
+++ b/src/Centeva.ObjectStorage.Azure.Blob/AzureBlobObjectStorage.cs
@@ -24,12 +24,9 @@ public class AzureBlobObjectStorage : IObjectStorage, ISupportsSignedUrls, ISupp
     }
 
     // Managed identity constructor
-    public AzureBlobObjectStorage(string accountName, string container, TokenCredential? identity, Uri? serviceUri = null)
+    public AzureBlobObjectStorage(string accountName, string container, TokenCredential identity, Uri? serviceUri = null)
     {
         _containerName = container;
-
-        // If we don't specify which identity to use, we default to DefaultAzureCredential which will try to use the running environment's identity
-        identity ??= new DefaultAzureCredential();
         _client = new BlobServiceClient(serviceUri ?? GetServiceUri(accountName), identity);
     }
 

--- a/src/Centeva.ObjectStorage.Azure.Blob/AzureBlobObjectStorage.cs
+++ b/src/Centeva.ObjectStorage.Azure.Blob/AzureBlobObjectStorage.cs
@@ -6,6 +6,8 @@ using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
 using Azure.Storage.Blobs.Specialized;
 using Azure.Storage.Sas;
+using Azure.Identity;
+using Azure.Core;
 
 namespace Centeva.ObjectStorage.Azure.Blob;
 
@@ -19,6 +21,16 @@ public class AzureBlobObjectStorage : IObjectStorage, ISupportsSignedUrls, ISupp
         _containerName = container;
         StorageSharedKeyCredential credentials = new(accountName, accountKey);
         _client = new BlobServiceClient(serviceUri ?? GetServiceUri(accountName), credentials);
+    }
+
+    // Managed identity constructor
+    public AzureBlobObjectStorage(string accountName, string container, TokenCredential? identity, Uri? serviceUri = null)
+    {
+        _containerName = container;
+
+        // If we don't specify which identity to use, we default to DefaultAzureCredential which will try to use the running environment's identity
+        identity ??= new DefaultAzureCredential();
+        _client = new BlobServiceClient(serviceUri ?? GetServiceUri(accountName), identity);
     }
 
     public async Task<IReadOnlyCollection<StorageEntry>> ListAsync(StoragePath? path = null, ListOptions options = default, CancellationToken cancellationToken = default)

--- a/src/Centeva.ObjectStorage.Azure.Blob/Centeva.ObjectStorage.Azure.Blob.csproj
+++ b/src/Centeva.ObjectStorage.Azure.Blob/Centeva.ObjectStorage.Azure.Blob.csproj
@@ -10,6 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Identity" Version="1.13.2" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.23.0" />
      <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="all" />
   </ItemGroup>

--- a/src/Centeva.ObjectStorage.Azure.Blob/StorageFactoryExtensions.cs
+++ b/src/Centeva.ObjectStorage.Azure.Blob/StorageFactoryExtensions.cs
@@ -8,6 +8,7 @@ public static class StorageFactoryExtensions
     public static StorageFactory UseAzureBlobStorage(this StorageFactory connectionFactory)
     {
         connectionFactory.Register(new AzureBlobConnectionFactory());
+        connectionFactory.Register(new AzureBlobIdentityConnectionFactory());
         return connectionFactory;
     }
 }

--- a/src/Centeva.ObjectStorage.Azure.Blob/StorageFactoryExtensions.cs
+++ b/src/Centeva.ObjectStorage.Azure.Blob/StorageFactoryExtensions.cs
@@ -8,7 +8,6 @@ public static class StorageFactoryExtensions
     public static StorageFactory UseAzureBlobStorage(this StorageFactory connectionFactory)
     {
         connectionFactory.Register(new AzureBlobConnectionFactory());
-        connectionFactory.Register(new AzureBlobIdentityConnectionFactory());
         return connectionFactory;
     }
 }


### PR DESCRIPTION
## Description

Adds a new connection factory for azure.blob which allows identity based authentication.
Will default to the inherent identity otherwise if a clientId is specified will use that as a managed identity.

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Tests
- [ ] 🤖 Build/CI
- [ ] 📦 Chore (Version bump, release, etc.)
- [ ] ⏩ Revert

## Changes Made

- Created AzureBlobIdentityConnectionFactory.
- Added secondary constructor for AzureBlobObjectStorage.
- Added package Azure.Identity.

## Quality Checklist

- [ ] I have added or updated automated tests as needed.
- [x] I have reviewed the code changes myself.
- [x] I have used commit messages that adequately explain my changes.
- [x] I have removed any extra logging, debugging code, and commented out code.
- [x] I have updated any related documentation (if necessary).

## Additional Notes

Adding tests for this is difficult with how our current testing infrastructure is setup.

