### PR TITLE
Allow specifying Content-Disposition header when writing object

### DIFF
--- a/src/Centeva.ObjectStorage.AWS/AwsS3ObjectStorage.cs
+++ b/src/Centeva.ObjectStorage.AWS/AwsS3ObjectStorage.cs
@@ -139,8 +139,6 @@ public class AwsS3ObjectStorage : IObjectStorage, ISupportsSignedUrls, ISupports
     
     public async Task WriteAsync(StoragePath path, Stream contentStream, WriteOptions? writeOptions = null, CancellationToken cancellationToken = default)
     {
-
-
         var request = new TransferUtilityUploadRequest
         {
             InputStream = contentStream,
@@ -148,6 +146,11 @@ public class AwsS3ObjectStorage : IObjectStorage, ISupportsSignedUrls, ISupports
             Key = path.WithoutLeadingSlash,
             BucketName = _bucketName
         };
+
+        if (writeOptions?.ContentDisposition is not null)
+        {
+            request.Headers.ContentDisposition = writeOptions.Value.ContentDisposition.ToString();
+        }
 
         if (writeOptions?.Metadata != null)
         {
@@ -273,7 +276,7 @@ public class AwsS3ObjectStorage : IObjectStorage, ISupportsSignedUrls, ISupports
         };
     }
 
-    private Dictionary<string, string> ConvertMetadata(GetObjectMetadataResponse response)
+    private static Dictionary<string, string> ConvertMetadata(GetObjectMetadataResponse response)
     {
         var metadata = new Dictionary<string, string>();
         foreach (var key in response.Metadata.Keys)

--- a/src/Centeva.ObjectStorage.Azure.Blob/AzureBlobObjectStorage.cs
+++ b/src/Centeva.ObjectStorage.Azure.Blob/AzureBlobObjectStorage.cs
@@ -129,7 +129,8 @@ public class AzureBlobObjectStorage : IObjectStorage, ISupportsSignedUrls, ISupp
         {
             HttpHeaders = new BlobHttpHeaders
             {
-                ContentType = writeOptions?.ContentType
+                ContentType = writeOptions?.ContentType,
+                ContentDisposition = writeOptions?.ContentDisposition?.ToString()
             },
             Metadata = writeOptions?.Metadata?.ToDictionary(kvp => kvp.Key, kvp => kvp.Value)
         };

--- a/src/Centeva.ObjectStorage.GCP/GoogleObjectStorage.cs
+++ b/src/Centeva.ObjectStorage.GCP/GoogleObjectStorage.cs
@@ -142,11 +142,12 @@ public class GoogleObjectStorage : IObjectStorage, ISupportsSignedUrls
 
     public async Task WriteAsync(StoragePath path, Stream contentStream, WriteOptions? writeOptions = null, CancellationToken cancellationToken = default)
     {
-         var obj = new Google.Apis.Storage.v1.Data.Object
+        var obj = new Google.Apis.Storage.v1.Data.Object
         {
             Bucket = _bucketName,
             Name = path.WithoutLeadingSlash,
             ContentType = writeOptions?.ContentType,
+            ContentDisposition = writeOptions?.ContentDisposition?.ToString(),
             Metadata = writeOptions?.Metadata?.ToDictionary(kvp => kvp.Key, kvp => kvp.Value)
         };
 

--- a/src/Centeva.ObjectStorage/WriteOptions.cs
+++ b/src/Centeva.ObjectStorage/WriteOptions.cs
@@ -1,8 +1,37 @@
+using System.Net.Mime;
+
 namespace Centeva.ObjectStorage;
 
 /// <summary>
 /// Options for writing storage entries
 /// </summary>
-/// <param name="ContentType">The content type of the entry</param>
-/// <param name="Metadata">The metadata of the entry</param>
-public record struct WriteOptions(string? ContentType, IReadOnlyDictionary<string, string>? Metadata);
+public record struct WriteOptions
+{
+    /// <summary>
+    /// (deprecated) Initializes a new instance of the <see cref="WriteOptions"/> class with the specified content type and metadata.
+    /// </summary>
+    /// <param name="contentType">The MIME type of the content to be written. Can be <see langword="null"/> if no specific content type is
+    /// required.</param>
+    /// <param name="metadata">A read-only dictionary containing metadata key-value pairs associated with the content. Can be <see
+    /// langword="null"/> if no metadata is provided.</param>
+    public WriteOptions(string? contentType, IReadOnlyDictionary<string, string>? metadata)
+    {
+        ContentType = contentType;
+        Metadata = metadata;
+    }
+
+    /// <summary>
+    /// The MIME content type of the entry
+    /// </summary>
+    public string? ContentType { get; set; }
+
+    /// <summary>
+    /// Value of a Content-Disposition header for the entry.
+    /// </summary>
+    public ContentDisposition? ContentDisposition { get; set; }
+
+    /// <summary>
+    /// Set of metadata key/value pairs to associate with the entry.
+    /// </summary>
+    public IReadOnlyDictionary<string, string>? Metadata { get; set; }
+}


### PR DESCRIPTION
## Description

When used with a cloud storage provider, it will store the HTTP header value with the blob such that when downloading via a signed URL or other mechanism, the header will be sent as part of the response.  This allows you to specify a filename that is separate from the object name as stored.

+semver:minor

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Tests
- [ ] 🤖 Build/CI
- [ ] 📦 Chore (Version bump, release, etc.)
- [ ] ⏩ Revert

## Quality Checklist

- [x] I have added or updated automated tests as needed.
- [x] I have reviewed the code changes myself.
- [x] I have used commit messages that adequately explain my changes.
- [x] I have removed any extra logging, debugging code, and commented out code.
- [x] I have updated any related documentation (if necessary).

## Additional Notes

<!--
Add any additional notes or context that may be helpful for reviewers.
-->
