### PR TITLE
fix: MinIO compatibility on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,15 @@ var storageFromConnectionString = factory.GetConnection("aws.s3://endpoint=http:
 var storageFromConstructor = new AwsS3ObjectStorage("myfiles", "us-east-1", "http://localhost:9000", "myAccount", "myPassword");
 ```
 
+### MinIO and macOS Compatibility
+
+When using MinIO or other S3-compatible storage services with custom endpoints on macOS,
+the library automatically uses `AuthenticationRegion` instead of `RegionEndpoint` to avoid
+DNS resolution conflicts with the AWS SDK. This ensures proper functionality across all
+platforms (Windows, Linux, and macOS) without requiring any special configuration.
+
+```
+
 **TODO:** Write API documentation
 
 ## Contributing

--- a/test/Centeva.ObjectStorage.IntegrationTests/Providers/AwsS3ObjectStorageTests.cs
+++ b/test/Centeva.ObjectStorage.IntegrationTests/Providers/AwsS3ObjectStorageTests.cs
@@ -152,4 +152,61 @@ public class AwsS3ObjectStorageTests : CommonObjectStorageTests, IClassFixture<A
         entry!.ContentType.ShouldBe(options.ContentType);
         entry!.Metadata.ShouldBeEquivalentTo(metadata);
     }
+
+    // Test for macOS compatibility with custom endpoints (MinIO)
+    [Fact]
+    public void Constructor_WithCustomEndpoint_DoesNotThrow()
+    {
+        // This test verifies the macOS compatibility fix where custom endpoints
+        // (like MinIO) use AuthenticationRegion instead of RegionEndpoint to avoid
+        // DNS resolution conflicts on macOS
+        var exception = Record.Exception(() =>
+        {
+            var storage = new AwsS3ObjectStorage(
+                bucketName: "test-bucket",
+                region: "us-east-1",
+                endpoint: "http://localhost:9000", // Custom endpoint (MinIO)
+                accessKey: "test-key",
+                secretKey: "test-secret"
+            );
+        });
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void Constructor_WithAwsEndpoint_DoesNotThrow()
+    {
+        // This test verifies standard AWS S3 configuration still works
+        var exception = Record.Exception(() =>
+        {
+            var storage = new AwsS3ObjectStorage(
+                bucketName: "test-bucket",
+                region: "us-east-1",
+                endpoint: null, // Standard AWS endpoint
+                accessKey: "test-key",
+                secretKey: "test-secret"
+            );
+        });
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void Constructor_WithCustomEndpointAndNoRegion_DoesNotThrow()
+    {
+        // Test custom endpoint without region specified
+        var exception = Record.Exception(() =>
+        {
+            var storage = new AwsS3ObjectStorage(
+                bucketName: "test-bucket",
+                region: null,
+                endpoint: "http://localhost:9000",
+                accessKey: "test-key",
+                secretKey: "test-secret"
+            );
+        });
+
+        Assert.Null(exception);
+    }
 }

--- a/test/Centeva.ObjectStorage.IntegrationTests/Providers/AwsS3ObjectStorageTests.cs
+++ b/test/Centeva.ObjectStorage.IntegrationTests/Providers/AwsS3ObjectStorageTests.cs
@@ -160,53 +160,44 @@ public class AwsS3ObjectStorageTests : CommonObjectStorageTests, IClassFixture<A
         // This test verifies the macOS compatibility fix where custom endpoints
         // (like MinIO) use AuthenticationRegion instead of RegionEndpoint to avoid
         // DNS resolution conflicts on macOS
-        var exception = Record.Exception(() =>
-        {
-            var storage = new AwsS3ObjectStorage(
-                bucketName: "test-bucket",
-                region: "us-east-1",
-                endpoint: "http://localhost:9000", // Custom endpoint (MinIO)
-                accessKey: "test-key",
-                secretKey: "test-secret"
-            );
-        });
+        var act = () => new AwsS3ObjectStorage(
+            bucketName: "test-bucket",
+            region: "us-east-1",
+            endpoint: "http://localhost:9000", // Custom endpoint (MinIO)
+            accessKey: "test-key",
+            secretKey: "test-secret"
+        );
 
-        Assert.Null(exception);
+        act.ShouldNotThrow();
     }
 
     [Fact]
     public void Constructor_WithAwsEndpoint_DoesNotThrow()
     {
         // This test verifies standard AWS S3 configuration still works
-        var exception = Record.Exception(() =>
-        {
-            var storage = new AwsS3ObjectStorage(
-                bucketName: "test-bucket",
-                region: "us-east-1",
-                endpoint: null, // Standard AWS endpoint
-                accessKey: "test-key",
-                secretKey: "test-secret"
-            );
-        });
+        var act = () => new AwsS3ObjectStorage(
+            bucketName: "test-bucket",
+            region: "us-east-1",
+            endpoint: null, // Standard AWS endpoint
+            accessKey: "test-key",
+            secretKey: "test-secret"
+        );
 
-        Assert.Null(exception);
+        act.ShouldNotThrow();
     }
 
     [Fact]
     public void Constructor_WithCustomEndpointAndNoRegion_DoesNotThrow()
     {
         // Test custom endpoint without region specified
-        var exception = Record.Exception(() =>
-        {
-            var storage = new AwsS3ObjectStorage(
-                bucketName: "test-bucket",
-                region: null,
-                endpoint: "http://localhost:9000",
-                accessKey: "test-key",
-                secretKey: "test-secret"
-            );
-        });
+        var act = () => new AwsS3ObjectStorage(
+            bucketName: "test-bucket",
+            region: null,
+            endpoint: "http://localhost:9000",
+            accessKey: "test-key",
+            secretKey: "test-secret"
+        );
 
-        Assert.Null(exception);
+        act.ShouldNotThrow();
     }
 }


### PR DESCRIPTION
## Description

  This PR fixes MinIO compatibility issues on macOS by restructuring how the AWS SDK S3 configuration handles custom endpoints vs. standard AWS endpoints.

  **The Problem:** When using MinIO (or other S3-compatible storage) on macOS, the AWS SDK has DNS resolution conflicts when both a custom endpoint and `RegionEndpoint` are configured simultaneously. This causes MinIO to fail on macOS while working fine
  on Windows/Linux.

  **The Solution:** Conditionally configure S3 client based on endpoint type:
  - **For custom endpoints (MinIO):** Use `AuthenticationRegion` (string) instead of `RegionEndpoint` property, avoiding AWS-specific DNS resolution
  - **For AWS S3:** Continue using `RegionEndpoint.GetBySystemName(region)` as before

  This allows MinIO to work properly on macOS while maintaining full AWS S3 compatibility.

  ## What type of PR is this? (check all applicable)

  - [ ] 🍕 Feature
  - [x] 🐛 Bug Fix
  - [ ] 📝 Documentation
  - [ ] 🎨 Style
  - [ ] 🧑‍💻 Code Refactor
  - [ ] 🔥 Performance Improvements
  - [ ] ✅ Tests
  - [ ] 🤖 Build/CI
  - [ ] 📦 Chore (Version bump, release, etc.)
  - [ ] ⏩ Revert

  ## Related Tickets & Documents

Non related tickets.

  ## Changes Made

  1. **Modified `CreateConfig` method in `AwsS3ObjectStorage.cs`:**
     - Added conditional logic to detect custom endpoints vs. AWS endpoints
     - For custom endpoints (MinIO):
       - Set `ServiceURL` to the custom endpoint
       - Use `AuthenticationRegion` (string) instead of `RegionEndpoint` property
       - Set `ForcePathStyle = true` for path-style bucket URLs
       - Determine HTTP vs HTTPS from endpoint URL
     - For AWS S3:
       - Continue using `RegionEndpoint.GetBySystemName(region)` as before

  2. **Why `AuthenticationRegion` vs `RegionEndpoint`:**
     - `AuthenticationRegion` only affects request signing, not DNS resolution
     - Prevents AWS SDK from trying to resolve custom endpoints using AWS DNS conventions
     - Fixes macOS-specific DNS conflicts that don't occur on Windows/Linux

  ## Screenshots (if applicable)

  N/A - Infrastructure/SDK configuration change

  ## Quality Checklist

  - [x] I have added or updated automated tests as needed.
  - [x] I have reviewed the code changes myself.
  - [x] I have used commit messages that adequately explain my changes.
  - [x] I have removed any extra logging, debugging code, and commented out code.
  - [x] I have updated any related documentation (if necessary).

  ## Additional Notes

  **Testing:** This fix has been tested with MinIO running locally on macOS. The application now successfully connects and performs storage operations.

  **Compatibility:** This change maintains backward compatibility with AWS S3 and doesn't affect Windows/Linux MinIO usage (which already worked).

  **Impact:** Developers using macOS can now run the application with MinIO for local development. Previously, they would encounter DNS resolution errors when the SDK tried to resolve MinIO endpoints using AWS conventions.


