### PR TITLE
Clean up build settings and update packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           dotnet-version: |
             8.x
-            9.x
+            10.x
         env:
           DOTNET_INSTALL_DIR: '~/dotnet'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,6 @@ jobs:
           source-url: https://nuget.pkg.github.com/centeva/index.json
           dotnet-version: |
             8.x
-            9.x
         env:
           DOTNET_INSTALL_DIR: '~/dotnet'
           NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,8 +8,10 @@
     <PackageProjectUrl>https://github.com/Centeva/Centeva.ObjectStorage</PackageProjectUrl>
   </PropertyGroup>
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
     <!-- Needed to avoid compiler issues with .NET Standard target -->
     <LangVersion>12</LangVersion>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 </Project>

--- a/src/Centeva.ObjectStorage.AWS/Centeva.ObjectStorage.AWS.csproj
+++ b/src/Centeva.ObjectStorage.AWS/Centeva.ObjectStorage.AWS.csproj
@@ -1,8 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Nullable>enable</Nullable>
-    <ImplicitUsings>enable</ImplicitUsings>
     <Description>AWS S3 compatible storage provider for Centeva.ObjectStorage</Description>
     <PackageIcon>icon.png</PackageIcon>
   </PropertyGroup>

--- a/src/Centeva.ObjectStorage.AWS/Centeva.ObjectStorage.AWS.csproj
+++ b/src/Centeva.ObjectStorage.AWS/Centeva.ObjectStorage.AWS.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="4.0.7.2" />
+    <PackageReference Include="AWSSDK.S3" Version="4.0.13.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="all" />
   </ItemGroup>
 

--- a/src/Centeva.ObjectStorage.Azure.Blob/Centeva.ObjectStorage.Azure.Blob.csproj
+++ b/src/Centeva.ObjectStorage.Azure.Blob/Centeva.ObjectStorage.Azure.Blob.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+    
   <PropertyGroup>
-    <Nullable>enable</Nullable>
-    <ImplicitUsings>enable</ImplicitUsings>
     <Description>Azure Blob Storage provider for Centeva.ObjectStorage</Description>
     <PackageIconUrl>icon.png</PackageIconUrl>
   </PropertyGroup>
@@ -9,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.16.0" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.25.0" />
-     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Centeva.ObjectStorage.Azure.Blob/Centeva.ObjectStorage.Azure.Blob.csproj
+++ b/src/Centeva.ObjectStorage.Azure.Blob/Centeva.ObjectStorage.Azure.Blob.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.16.0" />
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.25.0" />
+    <PackageReference Include="Azure.Identity" Version="1.17.1" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.26.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="all" />
   </ItemGroup>
 

--- a/src/Centeva.ObjectStorage.Azure.File/Centeva.ObjectStorage.Azure.File.csproj
+++ b/src/Centeva.ObjectStorage.Azure.File/Centeva.ObjectStorage.Azure.File.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.16.0" />
-    <PackageReference Include="Azure.Storage.Files.Shares" Version="12.23.0" />
+    <PackageReference Include="Azure.Identity" Version="1.17.1" />
+    <PackageReference Include="Azure.Storage.Files.Shares" Version="12.24.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="all" />
   </ItemGroup>
 

--- a/src/Centeva.ObjectStorage.Azure.File/Centeva.ObjectStorage.Azure.File.csproj
+++ b/src/Centeva.ObjectStorage.Azure.File/Centeva.ObjectStorage.Azure.File.csproj
@@ -1,28 +1,24 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
-        <Nullable>enable</Nullable>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <LangVersion>12.0</LangVersion>
-        <Description>Azure File Share Storage provider for Centeva.ObjectStorage</Description>
-        <PackageIconUrl>icon.png</PackageIconUrl>
-    </PropertyGroup>
+  <PropertyGroup>
+    <Description>Azure File Share Storage provider for Centeva.ObjectStorage</Description>
+    <PackageIconUrl>icon.png</PackageIconUrl>
+  </PropertyGroup>
 
-    <ItemGroup>
-        <PackageReference Include="Azure.Identity" Version="1.16.0" />
-        <PackageReference Include="Azure.Storage.Files.Shares" Version="12.23.0" />
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="all" />
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Azure.Identity" Version="1.16.0" />
+    <PackageReference Include="Azure.Storage.Files.Shares" Version="12.23.0" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="all" />
+  </ItemGroup>
 
-    <ItemGroup>
-        <ProjectReference Include="..\Centeva.ObjectStorage\Centeva.ObjectStorage.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Centeva.ObjectStorage\Centeva.ObjectStorage.csproj" />
+  </ItemGroup>
 
-    <ItemGroup>
-        <!-- Needed for nuget package -->
-        <None Include="..\..\README.md" Pack="true" PackagePath="" />
-        <None Include="..\..\icon.png" Pack="true" PackagePath="" />
-    </ItemGroup>
+  <ItemGroup>
+    <!-- Needed for nuget package -->
+    <None Include="..\..\README.md" Pack="true" PackagePath="" />
+    <None Include="..\..\icon.png" Pack="true" PackagePath="" />
+  </ItemGroup>
 
 </Project>

--- a/src/Centeva.ObjectStorage.GCP/Centeva.ObjectStorage.GCP.csproj
+++ b/src/Centeva.ObjectStorage.GCP/Centeva.ObjectStorage.GCP.csproj
@@ -1,8 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Nullable>enable</Nullable>
-    <ImplicitUsings>enable</ImplicitUsings>
     <Description>Google Cloud Storage provider for Centeva.ObjectStorage</Description>
     <PackageIcon>icon.png</PackageIcon>
   </PropertyGroup>

--- a/src/Centeva.ObjectStorage/Centeva.ObjectStorage.csproj
+++ b/src/Centeva.ObjectStorage/Centeva.ObjectStorage.csproj
@@ -1,8 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Nullable>enable</Nullable>
-    <ImplicitUsings>enable</ImplicitUsings>
     <Description>.NET object storage library that supports multiple storage providers</Description>
     <PackageIcon>icon.png</PackageIcon>
   </PropertyGroup>

--- a/test/Centeva.ObjectStorage.IntegrationTests/Centeva.ObjectStorage.IntegrationTests.csproj
+++ b/test/Centeva.ObjectStorage.IntegrationTests/Centeva.ObjectStorage.IntegrationTests.csproj
@@ -1,8 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Nullable>enable</Nullable>
-    <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>
     <UserSecretsId>c453a972-317c-44fd-b000-d5cf841315b6</UserSecretsId>
     <NoWarn>IDE1006</NoWarn>

--- a/test/Centeva.ObjectStorage.IntegrationTests/Centeva.ObjectStorage.IntegrationTests.csproj
+++ b/test/Centeva.ObjectStorage.IntegrationTests/Centeva.ObjectStorage.IntegrationTests.csproj
@@ -12,10 +12,10 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/test/Centeva.ObjectStorage.UnitTests/Centeva.ObjectStorage.UnitTests.csproj
+++ b/test/Centeva.ObjectStorage.UnitTests/Centeva.ObjectStorage.UnitTests.csproj
@@ -1,8 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Nullable>enable</Nullable>
-    <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/test/Centeva.ObjectStorage.UnitTests/Centeva.ObjectStorage.UnitTests.csproj
+++ b/test/Centeva.ObjectStorage.UnitTests/Centeva.ObjectStorage.UnitTests.csproj
@@ -5,10 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -1,7 +1,9 @@
 <Project>
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(GITHUB_ACTIONS)' == 'true'">net8.0;net9.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(GITHUB_ACTIONS)' != 'true'">net8.0;net9.0;net472</TargetFrameworks>
+    <TargetFrameworks Condition="'$(GITHUB_ACTIONS)' == 'true'">net10.0;</TargetFrameworks>
+    <TargetFrameworks Condition="'$(GITHUB_ACTIONS)' != 'true'">net10.0;net472</TargetFrameworks>
     <LangVersion>12</LangVersion>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
I consolidated the build setting for all the projects in the Directory.Build.props file, and standardized on net8.0 and netstandard2.0 for the target frameworks.  The test projects run under .NET 10.  (There was no reason to build a .NET 9 target as we don't use any features specific to that version,)

All package dependencies have been updated, but the Microsoft packages are left at version 8.x instead of 10.x.  (I'm not sure how that works with .NET 8 targets.)

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Tests
- [ ] 🤖 Build/CI
- [x] 📦 Chore (Version bump, release, etc.)
- [ ] ⏩ Revert



## Quality Checklist

- [x] I have added or updated automated tests as needed.
- [x] I have reviewed the code changes myself.
- [x] I have used commit messages that adequately explain my changes.
- [x] I have removed any extra logging, debugging code, and commented out code.
- [x] I have updated any related documentation (if necessary).

